### PR TITLE
add aiofiles to pipfile and requirements.txt 

### DIFF
--- a/project/requirements.txt
+++ b/project/requirements.txt
@@ -66,4 +66,5 @@ plotly==4.9.0
 uvicorn==0.11.8
 python-dotenv==0.14.0
 psycopg2-binary==2.8.6
+aiofiles==0.6.0
 


### PR DESCRIPTION
add aiofiles to pipfile and requirements.txt to enable the csv file feature on the live app. In order for us to see it on the live app, you'll have to 

1. Rebuild your docker file (docker-compose build)
2. Redeploy your elastic beanstalk app (eb deploy)